### PR TITLE
No load at startup. Only on first demand

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemrml/api/HTSMLService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrml/api/HTSMLService.java
@@ -1,0 +1,38 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemrml.api;
+
+import org.jpmml.evaluator.Evaluator;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.kenyaemrml.MLinKenyaEMRConfig;
+
+/**
+ * The main service of this module, which is exposed for other modules. See
+ * moduleApplicationContext.xml on how it is wired up.
+ */
+public interface HTSMLService extends OpenmrsService {
+		
+	/**
+	 * gets the IIT ML model evaluator
+	 * 
+	 * @return the evaluator
+	 */
+	@Authorized(MLinKenyaEMRConfig.MODULE_PRIVILEGE)
+	Evaluator getEvaluator();
+
+	/**
+	 * sets the IIT ML model evaluator
+	 * 
+	 * @param evaluator
+	 */
+	void setEvaluator(Evaluator evaluator);
+	
+}

--- a/api/src/main/java/org/openmrs/module/kenyaemrml/api/MLUtils.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrml/api/MLUtils.java
@@ -3,10 +3,6 @@ package org.openmrs.module.kenyaemrml.api;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -23,14 +19,11 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.openmrs.GlobalProperty;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.kenyaemr.api.KenyaEmrService;
-import org.openmrs.module.kenyaemrml.api.service.ModelService;
 import org.openmrs.module.kenyaemrml.domain.ModelInputFields;
 import org.openmrs.module.kenyaemrml.domain.ScoringResult;
-import org.openmrs.ui.framework.WebConstants;
 
 
 public class MLUtils {
@@ -399,7 +392,7 @@ public class MLUtils {
 	public static String generateIITMLScore(String payload) {
 		String mlScore = "";
 		try {
-			ModelService modelService = new ModelService();
+			ModelService modelService = Context.getService(ModelService.class);
 			String requestBody = payload;
 			ObjectNode modelConfigs = MLUtils.getModelConfig(requestBody);
 			String facilityMflCode = modelConfigs.get(MLUtils.FACILITY_ID_REQUEST_VARIABLE).asText();

--- a/api/src/main/java/org/openmrs/module/kenyaemrml/api/ModelService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrml/api/ModelService.java
@@ -1,0 +1,94 @@
+package org.openmrs.module.kenyaemrml.api;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.dmg.pmml.FieldName;
+import org.jpmml.evaluator.Evaluator;
+import org.jpmml.evaluator.FieldValue;
+import org.openmrs.Concept;
+import org.openmrs.Encounter;
+import org.openmrs.Obs;
+import org.openmrs.Patient;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.kenyaemrml.domain.ModelInputFields;
+import org.openmrs.module.kenyaemrml.domain.ScoringResult;
+import org.openmrs.module.kenyaemrml.iit.PatientRiskScore;
+import org.openmrs.ui.framework.SimpleObject;
+
+public interface ModelService extends OpenmrsService {
+	
+	ScoringResult htsscore(String modelId, String facilityName, String encounterDate, ModelInputFields inputFields,
+	        boolean debug);
+	
+	ScoringResult iitscore(String modelId, String facilityName, String encounterDate, ModelInputFields inputFields,
+	        boolean debug);
+
+	Map<String, Object> score(Evaluator evaluator, ModelInputFields inputFields, boolean debug);
+	
+	Map<FieldName, FieldValue> prepareEvaluationArgs(Evaluator evaluator, ModelInputFields inputFields);
+
+	Obs getLatestObs(Patient patient, String conceptIdentifier);
+
+	Integer getNumberOfObs(Patient patient, String conceptIdentifier);
+
+	Integer getHighViralLoadCount(Patient patient);
+
+	Double getLatestViralLoadCount(Patient patient);
+
+	Double getLatestHighViralLoadCount(Patient patient);
+
+	Double getLatestLowViralLoadCount(Patient patient);
+
+	Double getLatestSuppressedViralLoadCount(Patient patient);
+
+	Integer getAllViralLoadCountLastThreeYears(Patient patient);
+
+	Integer getHighViralLoadCountLastThreeYears(Patient patient);
+
+	Integer getLowViralLoadCount(Patient patient);
+
+	Integer getSuppressedViralLoadCount(Patient patient);
+
+	Integer getTotalAppointments(Patient patient);
+
+	SimpleObject getMissedAppointments(Patient patient);
+
+	Integer getHonouredAppointments(Patient patient);
+
+	SimpleObject getEncDetails(Set<Obs> obsList, Encounter e, List<Encounter> allClinicalEncounters);
+
+	boolean hasVisitOnDate(Date appointmentDate, Patient patient, List<Encounter> allEncounters);
+
+	boolean wasScheduledVisit(Encounter encounter);
+
+	Integer getTotalUnscheduledVisits(Patient patient);
+	
+	Integer getLatestARTAdherence(Patient patient);
+
+	Integer getLatestCTXAdherence(Patient patient);
+
+	Integer getTotalPoorARTAdherence(Patient patient);
+
+	Integer getTotalFairARTAdherence(Patient patient);
+
+	Integer getTotalPoorCTXAdherence(Patient patient);
+
+	Integer getTotalFairCTXAdherence(Patient patient);
+
+	Integer getTotalARTAdherence(Patient patient);
+
+	Integer getTotalCTXAdherence(Patient patient);
+
+	Double getChangeInWeightInTheLastSixMonths(Patient patient);
+
+	Double getChangeInBMIInTheLastSixMonths(Patient patient);
+
+	Obs getObsByConceptPatientAndDate(Patient patient, Concept concept, Date date);
+
+	PatientRiskScore generatePatientRiskScore(Patient patient);
+
+	long getMemoryConsumption();
+}

--- a/api/src/main/java/org/openmrs/module/kenyaemrml/api/impl/HTSMLServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrml/api/impl/HTSMLServiceImpl.java
@@ -19,19 +19,19 @@ import org.hibernate.SessionFactory;
 import org.jpmml.evaluator.Evaluator;
 import org.jpmml.evaluator.LoadingModelEvaluatorBuilder;
 import org.openmrs.api.impl.BaseOpenmrsService;
-import org.openmrs.module.kenyaemrml.api.IITMLService;
+import org.openmrs.module.kenyaemrml.api.HTSMLService;
 
-public class IITMLServiceImpl extends BaseOpenmrsService implements IITMLService {
+public class HTSMLServiceImpl extends BaseOpenmrsService implements HTSMLService {
 	
 	private SessionFactory sessionFactory;
 	private Evaluator evaluator = null;
 
 	private void init() {
 		try {
-			System.out.println("IIT ML: Model NOT loaded. Now loading");
-			String modelId = "XGB_IIT_02232023";
+			System.out.println("HTS ML: Model NOT loaded. Now loading");
+			String modelId = "hts_xgb_1211_jan_2023";
 			String fullModelZipFileName = modelId.concat(".pmml.zip");
-			fullModelZipFileName = "iit/" + fullModelZipFileName;
+			fullModelZipFileName = "hts/" + fullModelZipFileName;
 			InputStream stream = IITMLServiceImpl.class.getClassLoader().getResourceAsStream(fullModelZipFileName);
 			BufferedInputStream bistream = new BufferedInputStream(stream);
 			// Model name
@@ -40,18 +40,18 @@ public class IITMLServiceImpl extends BaseOpenmrsService implements IITMLService
 			ZipEntry ze = null;
 
 			while ((ze = zis.getNextEntry()) != null) {
-				System.out.println("IIT ML: Got entry: " + ze);
+				System.out.println("HTS ML: Got entry: " + ze);
 				if(ze.getName().trim().equalsIgnoreCase(fullModelFileName)) {
 					// Building a model evaluator from a PMML file
 					evaluator = new LoadingModelEvaluatorBuilder().load(zis).build();
 					evaluator.verify();
-					System.out.println("IIT ML: Created the IIT ML Evaluator. Should do this only once in a lifetime");
+					System.out.println("HTS ML: Created the HTS ML Evaluator. Should do this only once in a lifetime");
 					break;
 				}
 			}
 		}
 		catch (Exception e) {
-			System.err.println("IIT ML. Init model error: " + e.getMessage());
+			System.err.println("HTS ML. Init model error: " + e.getMessage());
 			e.printStackTrace();
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/kenyaemrml/api/impl/MLinKenyaEMRServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrml/api/impl/MLinKenyaEMRServiceImpl.java
@@ -20,8 +20,8 @@ import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.kenyaemrml.api.MLinKenyaEMRService;
+import org.openmrs.module.kenyaemrml.api.ModelService;
 import org.openmrs.module.kenyaemrml.api.db.hibernate.HibernateMLinKenyaEMRDao;
-import org.openmrs.module.kenyaemrml.api.service.ModelService;
 import org.openmrs.module.kenyaemrml.iit.PatientRiskScore;
 import org.openmrs.ui.framework.SimpleObject;
 
@@ -30,8 +30,6 @@ public class MLinKenyaEMRServiceImpl extends BaseOpenmrsService implements MLinK
 	HibernateMLinKenyaEMRDao mLinKenyaEMRDao;
 	
 	UserService userService;
-
-	ModelService modelService;
 	
 	/**
 	 * Injected in moduleApplicationContext.xml
@@ -45,13 +43,6 @@ public class MLinKenyaEMRServiceImpl extends BaseOpenmrsService implements MLinK
 	 */
 	public void setUserService(UserService userService) {
 		this.userService = userService;
-	}
-
-	/**
-	 * Injected in moduleApplicationContext.xml
-	 */
-	public void setModelService(ModelService modelService) {
-		this.modelService = modelService;
 	}
 	
 	@Override
@@ -83,6 +74,7 @@ public class MLinKenyaEMRServiceImpl extends BaseOpenmrsService implements MLinK
 
 			if(gpIITFeatureEnabled != null && gpIITFeatureEnabled.getPropertyValue().trim().equalsIgnoreCase("true")) {
 				// System.out.println("IIT ML Score: Generating a new risk score || and saving to DB");
+				ModelService modelService = Context.getService(ModelService.class);
 				PatientRiskScore patientRiskScore = modelService.generatePatientRiskScore(patient);
 				// Save/Update to DB (for reports) -- Incase a record for current date doesnt exist
 				saveOrUpdateRiskScore(patientRiskScore);
@@ -101,6 +93,7 @@ public class MLinKenyaEMRServiceImpl extends BaseOpenmrsService implements MLinK
 
         if(gpIITFeatureEnabled != null && gpIITFeatureEnabled.getPropertyValue().trim().equalsIgnoreCase("true")) {
 			// System.out.println("IIT ML Score: Generating a new risk score || and saving to DB");
+			ModelService modelService = Context.getService(ModelService.class);
 			PatientRiskScore patientRiskScore = modelService.generatePatientRiskScore(patient);
 			// Save/Update to DB (for reports) -- Incase a record for current date doesnt exist
 			saveOrUpdateRiskScore(patientRiskScore);

--- a/api/src/main/java/org/openmrs/module/kenyaemrml/util/MLDataExchange.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemrml/util/MLDataExchange.java
@@ -69,8 +69,9 @@ import org.openmrs.ui.framework.SimpleObject;
 import java.text.SimpleDateFormat;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.kenyaemrml.api.service.ModelService;
 import org.apache.commons.lang.time.DateUtils;
+import org.openmrs.module.kenyaemrml.api.ModelService;
+
 
 public class MLDataExchange {
 	
@@ -691,7 +692,7 @@ public class MLDataExchange {
         GlobalProperty gpIITFeatureEnabled = Context.getAdministrationService().getGlobalPropertyObject(iitFeatureEnabled);
 
         if(gpIITFeatureEnabled != null && gpIITFeatureEnabled.getPropertyValue().trim().equalsIgnoreCase("true")) {
-			ModelService modelService = new ModelService();
+			ModelService modelService = Context.getService(ModelService.class);
 			long totalRemote = patientsGroup.size();
 			long totalPages = patientsGroup.size();
 			long currentPage = 1;
@@ -760,8 +761,7 @@ public class MLDataExchange {
 	 * @param patientsGroup - the given list of patients
 	 */
 	public void generateMLScoresFetch(HashSet<Patient> patientsGroup) {
-
-		ModelService modelService = new ModelService();
+		ModelService modelService = Context.getService(ModelService.class);
 		for (Patient patient : patientsGroup) {
 			try {
 				System.out.println("IIT ML Score: Scoring patient: " + patient.getId());

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -28,29 +28,21 @@
     <!-- Wraps MLinKenyaEMRService methods in DB transactions and OpenMRS interceptors,
     which set audit info like dateCreated, changedBy, etc.-->
 
-    <!-- Adds MLinKenyaEMRService to OpenMRS context so it can be accessed
+    <!-- Adds MLinKenyaEMRService to OpenMRS context so it can be accessed - moduleService
     calling Context.getService(MLinKenyaEMRService.class) -->
 
     <bean parent="serviceContext">
         <property name="moduleService">
             <list>
                 <value>org.openmrs.module.kenyaemrml.api.MLinKenyaEMRService</value>
-                <bean
-                        class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+                <bean class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
                     <property name="transactionManager">
                         <ref bean="transactionManager" />
                     </property>
                     <property name="target">
-                        <bean class="org.openmrs.module.kenyaemrml.api.impl.MLinKenyaEMRServiceImpl">
+                        <bean id="mLinKenyaEMRService" class="org.openmrs.module.kenyaemrml.api.impl.MLinKenyaEMRServiceImpl">
                             <property name="mLinKenyaEMRDao">
-                                <bean class="org.openmrs.module.kenyaemrml.api.db.hibernate.HibernateMLinKenyaEMRDao">
-                                    <property name="sessionFactory">
-                                        <ref bean="sessionFactory" />
-                                    </property>
-                                </bean>
-                            </property>
-                            <property name="modelService">
-                                <bean class="org.openmrs.module.kenyaemrml.api.service.ModelService">
+                                <bean id="hibernateMLinKenyaEMRDao" class="org.openmrs.module.kenyaemrml.api.db.hibernate.HibernateMLinKenyaEMRDao">
                                     <property name="sessionFactory">
                                         <ref bean="sessionFactory" />
                                     </property>
@@ -69,24 +61,19 @@
         </property>
     </bean>
 
-    <!-- Lets see if we can load only once -->
+    <!-- Model Service -->
     <bean parent="serviceContext">
         <property name="moduleService">
             <list>
-                <value>org.openmrs.module.kenyaemrml.api.service.ModelService</value>
-                <bean
-                        class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+                <value>org.openmrs.module.kenyaemrml.api.ModelService</value>
+                <bean class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
                     <property name="transactionManager">
                         <ref bean="transactionManager" />
                     </property>
                     <property name="target">
-                        <bean class="org.openmrs.module.kenyaemrml.api.service.ModelService">
-                            <property name="iITMLService">
-                                <bean class="org.openmrs.module.kenyaemrml.api.impl.IITMLServiceImpl">
-                                    <property name="sessionFactory">
-                                        <ref bean="sessionFactory" />
-                                    </property>
-                                </bean>
+                        <bean id="modelService" class="org.openmrs.module.kenyaemrml.api.impl.ModelServiceImpl">
+                            <property name="sessionFactory">
+                                <ref bean="sessionFactory" />
                             </property>
                         </bean>
                     </property>
@@ -101,18 +88,44 @@
         </property>
     </bean>
 
-    <!-- Lets see if we can load only once -->
+    <!-- IIT Model -->
     <bean parent="serviceContext">
         <property name="moduleService">
             <list>
                 <value>org.openmrs.module.kenyaemrml.api.IITMLService</value>
-                <bean
-                        class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+                <bean class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
                     <property name="transactionManager">
                         <ref bean="transactionManager" />
                     </property>
                     <property name="target">
-                        <bean class="org.openmrs.module.kenyaemrml.api.impl.IITMLServiceImpl">
+                        <bean id="iITMLService" class="org.openmrs.module.kenyaemrml.api.impl.IITMLServiceImpl">
+                            <property name="sessionFactory">
+                                <ref bean="sessionFactory" />
+                            </property>
+                        </bean>
+                    </property>
+                    <property name="preInterceptors">
+                        <ref bean="serviceInterceptors" />
+                    </property>
+                    <property name="transactionAttributeSource">
+                        <ref bean="transactionAttributeSource" />
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <!-- HTS Model -->
+    <bean parent="serviceContext">
+        <property name="moduleService">
+            <list>
+                <value>org.openmrs.module.kenyaemrml.api.HTSMLService</value>
+                <bean class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+                    <property name="transactionManager">
+                        <ref bean="transactionManager" />
+                    </property>
+                    <property name="target">
+                        <bean id="hTSMLService" class="org.openmrs.module.kenyaemrml.api.impl.HTSMLServiceImpl">
                             <property name="sessionFactory">
                                 <ref bean="sessionFactory" />
                             </property>

--- a/omod/src/main/java/org/openmrs/module/kenyaemrml/web/controller/MachineLearningRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemrml/web/controller/MachineLearningRestController.java
@@ -6,7 +6,7 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.node.ObjectNode;
 import org.json.simple.JSONObject;
 import org.openmrs.module.kenyaemrml.api.MLUtils;
-import org.openmrs.module.kenyaemrml.api.service.ModelService;
+import org.openmrs.module.kenyaemrml.api.ModelService;
 import org.openmrs.module.kenyaemrml.domain.ModelInputFields;
 import org.openmrs.module.kenyaemrml.domain.ScoringResult;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -220,7 +220,7 @@ public class MachineLearningRestController extends BaseRestController {
 	@RequestMapping(method = RequestMethod.POST, value = "/casefindingscore")
 	@ResponseBody
 	public Object processHTSModel(HttpServletRequest request) {
-		ModelService modelService = new ModelService();
+		ModelService modelService = Context.getService(ModelService.class);
 		String requestBody = null;
 		try {
 			requestBody = MLUtils.fetchRequestBody(request.getReader());
@@ -381,7 +381,7 @@ public class MachineLearningRestController extends BaseRestController {
 	@RequestMapping(method = RequestMethod.POST, value = "/iitscore")
 	@ResponseBody
 	public Object processIITModel(HttpServletRequest request) {
-		ModelService modelService = new ModelService();
+		ModelService modelService = Context.getService(ModelService.class);
 		String requestBody = null;
 		try {
 			requestBody = MLUtils.fetchRequestBody(request.getReader());


### PR DESCRIPTION
No load at startup. Only on first demand

NB: Now we don't load the model on startup. We load on first demand. This means that for those sites which have IIT ML disabled, it doesn't load at all. Ever. For the sites with IIT ML enabled, we load only when demanded first, then reuse the model for subsequent requests.

